### PR TITLE
Fix return_dict error and allow for hidden_states in ModernBERT

### DIFF
--- a/mlx_embeddings/models/modernbert.py
+++ b/mlx_embeddings/models/modernbert.py
@@ -321,6 +321,10 @@ class ModernBertModel(nn.Module):
 
             hidden_states = layer_outputs[0]
 
+        if output_hidden_states: 
+            all_hidden_states = all_hidden_states + (hidden_states,)
+
+
         hidden_states = self.final_norm(hidden_states)
 
         if not return_dict:
@@ -431,6 +435,7 @@ class Model(nn.Module):
         attention_mask: Optional[mx.array] = None,
         position_ids: Optional[mx.array] = None,
         return_dict: Optional[bool] = False,
+        output_hidden_states: Optional[bool] = False 
     ):
 
         if attention_mask is None:
@@ -445,7 +450,7 @@ class Model(nn.Module):
             input_ids,
             attention_mask=attention_mask,
             position_ids=position_ids,
-            output_hidden_states=None,  # only last_hidden_state is returned
+            output_hidden_states=output_hidden_states,  
             return_dict=return_dict,
         )
         last_hidden_state = (
@@ -478,12 +483,20 @@ class Model(nn.Module):
         # normalized features
         text_embeds = normalize_embeddings(last_hidden_state)
 
-        return BaseModelOutput(
-            last_hidden_state=last_hidden_state,
-            text_embeds=text_embeds,
-            pooler_output=pooled_output,
-            hidden_states=encoder_outputs[1:],
-        )
+        if return_dict: 
+            return {
+                'last_hidden_state' : last_hidden_state,
+                'text_embeds' : text_embeds,
+                'pooler_output' : pooled_output, 
+                'hidden_states' : encoder_outputs['hidden_states']
+            }
+        else:
+            return BaseModelOutput(
+                last_hidden_state=last_hidden_state,
+                text_embeds=text_embeds,
+                pooler_output=pooled_output,
+                hidden_states=encoder_outputs[1:],
+            )
 
     def sanitize(self, weights):
         sanitized_weights = {}


### PR DESCRIPTION
1. Using `return_dict=True` with Model in `modernbert.py` will return `KeyError: slice(1, None, None)` due to trying to access a dictionary as if it was a tuple on line 485. 

This fixes that and also returns a dictionary if user specifies. 

2. Some users might want to get hidden states so that they can get the last_hidden_state without layer normalization (For instance, I am currently trying to implement a pytorch neural net that uses pre-layer normalization embeddings into mlx). 

Edited parameter of Model with `output_hidden_states: Optional[bool] = False` that is reflected on `ModernBertModel` to allow for that feature, additionally add `(hidden,_states),` after looping through layers as that is done in the transformers library [like here](https://github.com/huggingface/transformers/blob/049a674e681181c2616fec4124086ec0ec55ed2d/src/transformers/models/modernbert/modular_modernbert.py#L998) for a total of 23 layers on hidden_states instead of 22 