### PR TITLE
make mlx_vlm optional

### DIFF
--- a/mlx_embeddings/utils.py
+++ b/mlx_embeddings/utils.py
@@ -16,7 +16,6 @@ import mlx.nn as nn
 from huggingface_hub import snapshot_download
 from huggingface_hub.errors import RepositoryNotFoundError
 from mlx.utils import tree_flatten, tree_unflatten
-
 from transformers import AutoProcessor, PreTrainedTokenizer
 
 from .tokenizer_utils import TokenizerWrapper, load_tokenizer


### PR DESCRIPTION
This will save dependencies from mlx_vlm in most cases when we don't need to process images