### PR TITLE
Microsoft Harrier OSS support 

### DIFF
--- a/mlx_embeddings/models/gemma3_text.py
+++ b/mlx_embeddings/models/gemma3_text.py
@@ -70,9 +70,24 @@ class Model(nn.Module):
         self.config = config
         self.model_type = config.model_type
         self.model = Gemma3Model(config)
+        self.dense = []
+
+    def _configure_dense_layers(self, weights):
+        dense_indices = sorted(
+            {
+                int(match.group(1))
+                for key in weights
+                if (match := re.fullmatch(r"dense\.(\d+)\.weight", key)) is not None
+            }
+        )
+
+        if not dense_indices:
+            self.dense = []
+            return
+
         self.dense = [
-            nn.Linear(config.hidden_size, config.hidden_size * 4, bias=False),
-            nn.Linear(config.hidden_size * 4, config.hidden_size, bias=False),
+            nn.Linear(weights[f"dense.{index}.weight"].shape[1], weights[f"dense.{index}.weight"].shape[0], bias=False)
+            for index in dense_indices
         ]
 
     def get_extended_attention_mask(self, attention_mask, input_shape):
@@ -141,6 +156,7 @@ class Model(nn.Module):
             else:
                 sanitized_weights[k] = v
 
+        self._configure_dense_layers(sanitized_weights)
         return sanitized_weights
 
     @property


### PR DESCRIPTION
This change adds support for Microsoft Harrier OSS by implementing a more generic code path for gemma3_text embeddings that doesn't require dense heads. This PR is meant to be challenged strongly by you @Blaizzy please :) We know each other from [my last MLX audio patch](https://github.com/Blaizzy/mlx-audio/pull/398#issuecomment-3797037523) that eventually got merged. This time I'm not sure if this generic solution would still be compatible with all other Gemma 3 embedding model type variants. Do we have any e2e/integration tests? I'd love to see projects like this having a Makefile where you simply do: `make e2e` and it runs thru all models, downloads them one by one, drops them again, and runs inference per-model. Only this way we could get 100% certainty that every code change does well. Not sure but we have Github Actions with macOS runners. Maybe we can even automate this...?