### PR TITLE
Add GTE-Reranker-ModernBERT-Base support with reranking example and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,39 @@ for idx, logit in enumerate(predictions.tolist()):
     print(f"{label}: {logit:.3f}")
 ```
 
+#### Text Reranking
+
+To rerank documents against a query using a cross-encoder reranker model:
+
+```python
+import mlx.core as mx
+from mlx_embeddings.utils import load, generate
+
+# Load the reranker model and tokenizer
+model, tokenizer = load("Alibaba-NLP/gte-reranker-modernbert-base")
+
+# Define query-document pairs
+pairs = [
+    ["what is the capital of China?", "Beijing"],
+    ["how to implement quick sort in python?", "Introduction of quick sort"],
+    ["how to implement quick sort in python?", "The weather is nice today"],
+]
+
+# Generate reranking scores
+output = generate(model, tokenizer, texts=pairs, max_length=8192)
+scores = output.pooler_output.squeeze()
+
+mx.eval(scores)
+
+# Print results
+print("Reranking scores:")
+for pair, score in zip(pairs, scores.tolist()):
+    print(f"  Query: {pair[0]}")
+    print(f"  Document: {pair[1]}")
+    print(f"  Score: {score:.4f}")
+    print()
+```
+
 #### Token Classification (PII detection)
 
 `openai/privacy-filter` is a bidirectional 1.5B-parameter / 50M-active sparse-MoE token classifier that tags personally identifiable information (PII) with BIOES spans over 8 categories (person, email, phone, URL, address, date, account number, secret).

--- a/mlx_embeddings/tests/test_models.py
+++ b/mlx_embeddings/tests/test_models.py
@@ -325,6 +325,44 @@ class TestModels(unittest.TestCase):
             text_embeds_is_sequence=False,
         )
 
+    def test_modernbert_model_sequence_classification(self):
+        from mlx_embeddings.models import modernbert
+
+        config = modernbert.ModelArgs(
+            architectures=["ModernBertForSequenceClassification"],
+            model_type="modernbert",
+            hidden_size=768,
+            num_hidden_layers=22,
+            intermediate_size=1152,
+            num_attention_heads=12,
+            max_position_embeddings=8192,
+            vocab_size=50368,
+            id2label={"0": "LABEL_0"},
+            label2id={"LABEL_0": 0},
+            classifier_pooling="mean",
+        )
+        model = modernbert.Model(config)
+
+        batch_size = 1
+        seq_length = 5
+
+        model.update(tree_map(lambda p: p.astype(mx.float32), model.parameters()))
+
+        inputs = mx.array([[0, 1, 2, 3, 4]])
+        outputs = model(inputs)
+
+        self.assertEqual(model.config.model_type, "modernbert")
+        self.assertEqual(len(model.model.layers), config.num_hidden_layers)
+        self.assertEqual(outputs.last_hidden_state.dtype, mx.float32)
+        self.assertEqual(
+            outputs.last_hidden_state.shape, (batch_size, config.hidden_size)
+        )
+        self.assertIsNotNone(outputs.pooler_output)
+        self.assertEqual(outputs.pooler_output.shape, (batch_size, 1))
+        # sigmoid output should be between 0 and 1
+        self.assertTrue(mx.all(outputs.pooler_output >= 0.0).item())
+        self.assertTrue(mx.all(outputs.pooler_output <= 1.0).item())
+
     def test_siglip_model(self):
         from mlx_embeddings.models import siglip
 

--- a/mlx_embeddings/utils.py
+++ b/mlx_embeddings/utils.py
@@ -388,7 +388,7 @@ def upload_to_hub(path: str, upload_repo: str, hf_path: str, config: dict):
         print(similarity_matrix)
         """
 
-        if config.get("architectures", None) == "ModernBertForMaskedLM":
+        if config.get("architectures", None) == ["ModernBertForMaskedLM"]:
             text_example = """
             # For masked language modeling
             output = generate(model, processor, texts=["The capital of France is [MASK]."])\n
@@ -396,6 +396,25 @@ def upload_to_hub(path: str, upload_repo: str, hf_path: str, config: dict):
             predicted_token_id = mx.argmax(output.logits[0, mask_index], axis=-1)\n
             predicted_token = processor.decode([predicted_token_id.item()])
             """
+        elif config.get("architectures", None) == [
+            "ModernBertForSequenceClassification"
+        ]:
+            text_example = """
+        # For reranking (sequence classification)
+        pairs = [
+            ["what is the capital of China?", "Beijing"],
+            ["how to implement quick sort in python?", "Introduction of quick sort"],
+        ]
+        output = generate(model, processor, texts=pairs, max_length=8192)
+        scores = output.pooler_output.squeeze()
+
+        print("Reranking scores:")
+        for pair, score in zip(pairs, scores.tolist()):
+            print(f"  Query: {pair[0]}")
+            print(f"  Document: {pair[1]}")
+            print(f"  Score: {score:.4f}")
+            print()
+        """
 
         response = text_example
     else:
@@ -575,7 +594,7 @@ def prepare_inputs(
 def generate(
     model: nn.Module,
     processor: Union[PreTrainedTokenizer, TokenizerWrapper, AutoProcessor],
-    texts: Union[str, List[str]],
+    texts: Union[str, List[str], List[List[str]]],
     images: Union[str, mx.array, List[str], List[mx.array]] = None,
     max_length: int = 512,
     padding: bool = True,
@@ -588,7 +607,9 @@ def generate(
     Args:
         model (nn.Module): The MLX model for generating embeddings.
         tokenizer (TokenizerWrapper): The tokenizer for preprocessing text.
-        texts (Union[str, List[str]]): A single text string or a list of text strings.
+        texts (Union[str, List[str], List[List[str]]]): A single text string,
+            a list of text strings, or a list of text pairs for reranking
+            (e.g. [["query", "document1"], ["query", "document2"]]).
 
     Returns:
         mx.array: The generated embeddings.


### PR DESCRIPTION
## Summary

Adds full support for the [Alibaba-NLP/gte-reranker-modernbert-base](https://huggingface.co/Alibaba-NLP/gte-reranker-modernbert-base) cross-encoder reranker model.

The existing `modernbert.py` already handled `ModernBertForSequenceClassification` architecture, but it lacked tests, documentation, and the `generate()` function didn't accept text pairs needed for reranking.

### Changes:

- **`mlx_embeddings/utils.py`**:
  - Updated `generate()` type signature to accept `List[List[str]]` (text pairs for reranking)
  - Added reranker-specific example in `upload_to_hub()` for `ModernBertForSequenceClassification`
  - Fixed bug: `architectures` comparison for `ModernBertForMaskedLM` was comparing a list to a string instead of a list

- **`mlx_embeddings/tests/test_models.py`**:
  - Added `test_modernbert_model_sequence_classification` test that validates the model works correctly with sigmoid output range verification

- **`README.md`**:
  - Added "Text Reranking" section with a complete usage example for `Alibaba-NLP/gte-reranker-modernbert-base`