### PR TITLE
Add Qwen3 Bidirectional encoder (voyage-4-nano support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ MLX-Embeddings supports a variety of model architectures for text embedding task
 - BERT (Bidirectional Encoder Representations from Transformers)
 - ModernBERT (modernized bidirectional encoder-only Transformer model)
 - Qwen3 (Qwen3's embedding model)
+- Qwen3 Bidirectional (Qwen3-based bidirectional encoders with optional Matryoshka projection head, e.g. voyage-4-nano)
 - Qwen3-VL (multimodal Qwen3-VL embedding and reranking model)
 - Llama Bidirectional (Llama-based bidirectional embedding models, e.g. NVIDIA NV-Embed)
 - Llama Nemotron VL (multimodal vision-language embedding model with SigLIP vision + bidirectional Llama)

--- a/mlx_embeddings/models/qwen3_bidirec.py
+++ b/mlx_embeddings/models/qwen3_bidirec.py
@@ -1,0 +1,175 @@
+"""Bidirectional Qwen3 embedding model (encoder-only variant).
+
+Mirror of :mod:`mlx_embeddings.models.llama_bidirec` for the Qwen3
+architecture: same transformer building blocks as ``qwen3.py`` (RoPE,
+GQA, q/k norm, RMSNorm) but the model swaps the autoregressive causal
+mask for a full bidirectional attention mask, and the embedding head
+uses mean pooling rather than last-token pooling.
+
+Optionally appends a ``nn.Linear`` projection head (when
+``num_labels`` is set in config), which is how
+`voyage-4-nano <https://huggingface.co/voyageai/voyage-4-nano>`_
+implements its Matryoshka output (hidden_size 1024 → 2048d).
+
+Used by models whose HuggingFace ``config.json`` declares
+``"model_type": "qwen3"`` together with
+``"use_bidirectional_attention": true`` — :func:`mlx_embeddings.utils._get_model_arch`
+routes that combination to this module.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .base import BaseModelArgs, BaseModelOutput, normalize_embeddings
+from .pooling import mean_pooling
+from .qwen3 import ModelArgs as Qwen3ModelArgs
+from .qwen3 import Qwen3DecoderLayer
+
+
+@dataclass
+class ModelArgs(Qwen3ModelArgs):
+    """Bidirectional Qwen3 args.
+
+    Inherits every field from :class:`mlx_embeddings.models.qwen3.ModelArgs`
+    so the existing :class:`Qwen3DecoderLayer` works unchanged. Adds:
+
+    * ``model_type`` defaults to ``"qwen3_bidirec"`` (matches the
+      module name for routing).
+    * ``num_labels`` — when set, a per-token linear projection is
+      appended before pooling. Used for Matryoshka outputs (e.g.
+      voyage-4-nano: ``hidden_size=1024`` → ``num_labels=2048``).
+    """
+
+    model_type: str = "qwen3_bidirec"
+    num_labels: Optional[int] = None
+
+
+class Qwen3BidirectionalModel(nn.Module):
+    """Qwen3 transformer with bidirectional attention.
+
+    Identical layer composition to :class:`mlx_embeddings.models.qwen3.Qwen3Model`
+    (same :class:`Qwen3DecoderLayer` stack, same embedding, same final
+    norm), but the forward pass passes the caller-supplied attention
+    mask straight through to the layers without combining it with a
+    causal triangle. The mask construction lives in the wrapping
+    :class:`Model` class.
+    """
+
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.config = args
+        self.vocab_size = args.vocab_size
+        self.num_hidden_layers = args.num_hidden_layers
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [Qwen3DecoderLayer(args) for _ in range(args.num_hidden_layers)]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        attention_mask: Optional[mx.array] = None,
+    ) -> mx.array:
+        h = self.embed_tokens(input_ids)
+        for layer in self.layers:
+            h = layer(h, attention_mask=attention_mask)
+        return self.norm(h)
+
+
+class Model(nn.Module):
+    """Bidirectional Qwen3 embedding model with optional Matryoshka head.
+
+    Voyage-4-nano shape:
+
+    * Forward pass through :class:`Qwen3BidirectionalModel` with a
+      padding-only mask (no causal triangle).
+    * Optional linear projection (``self.linear``) applied per-token
+      when ``config.num_labels`` is set.
+    * Mean pooling over the unmasked positions.
+    * L2 normalization.
+    """
+
+    def __init__(self, config: ModelArgs):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.model = Qwen3BidirectionalModel(config)
+        # Optional Matryoshka projection head (voyage-4-nano:
+        # hidden_size 1024 -> num_labels 2048).
+        self.linear = (
+            nn.Linear(config.hidden_size, config.num_labels, bias=False)
+            if config.num_labels is not None
+            else None
+        )
+
+    def get_extended_attention_mask(self, attention_mask: mx.array) -> mx.array:
+        """Expand a (batch, seq) padding mask to (batch, 1, seq, seq) shape.
+
+        Bidirectional: every query position attends to every key
+        position that isn't padding.
+        """
+        if attention_mask.ndim == 3:
+            return attention_mask[:, None, :, :]
+        if attention_mask.ndim == 2:
+            extended = attention_mask[:, None, None, :]
+            return mx.repeat(extended, attention_mask.shape[-1], -2)
+        raise ValueError(
+            f"Wrong shape for attention_mask (shape {attention_mask.shape})"
+        )
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        attention_mask: Optional[mx.array] = None,
+    ) -> BaseModelOutput:
+        if attention_mask is None:
+            attention_mask = mx.ones(input_ids.shape)
+
+        extended = self.get_extended_attention_mask(attention_mask)
+        extended = mx.where(extended.astype(mx.bool_), 0.0, -mx.inf)
+        extended = extended.astype(self.model.embed_tokens.weight.dtype)
+
+        out = self.model(input_ids, extended)
+
+        # Matryoshka projection: per-token linear before pooling.
+        if self.linear is not None:
+            out = self.linear(out)
+
+        text_embeds = mean_pooling(out, attention_mask)
+        text_embeds = normalize_embeddings(text_embeds)
+
+        return BaseModelOutput(
+            last_hidden_state=out,
+            text_embeds=text_embeds,
+            pooler_output=None,
+        )
+
+    def sanitize(self, weights: dict) -> dict:
+        """Map upstream safetensors keys onto this Model's parameter tree.
+
+        Two non-default rules:
+
+        * ``lm_head.weight`` — generative head, not used for embeddings.
+        * ``linear.weight`` / ``linear.bias`` — the projection head is
+          stored at the top level of upstream's HuggingFace module
+          (alongside ``model.*``), so it must be kept top-level here
+          too. The catchall ``model.`` prefix below would otherwise
+          rewrite it and ``load_weights`` would fail with "parameters
+          not in model".
+        """
+        sanitized_weights: dict = {}
+        for k, v in weights.items():
+            if "lm_head.weight" in k:
+                continue
+            if k in ("linear.weight", "linear.bias"):
+                sanitized_weights[k] = v
+                continue
+            new_key = k if k.startswith("model.") else f"model.{k}"
+            sanitized_weights[new_key] = v
+        return sanitized_weights
+
+    @property
+    def layers(self):
+        return self.model.layers

--- a/mlx_embeddings/utils.py
+++ b/mlx_embeddings/utils.py
@@ -34,6 +34,16 @@ class ModelNotFoundError(Exception):
 def _get_model_arch(config: dict):
     model_type = config["model_type"].replace("-", "_")
     model_type = MODEL_REMAPPING.get(model_type, model_type)
+
+    # Bidirectional encoder variants share the same upstream
+    # `model_type` as the decoder base they're derived from
+    # (e.g. voyage-4-nano has `model_type="qwen3"` and signals the
+    # encoder shape with `use_bidirectional_attention=True`). Route
+    # those to the matching `_bidirec` module so they get the
+    # encoder-style mask + pooling + optional projection head.
+    if model_type == "qwen3" and config.get("use_bidirectional_attention") is True:
+        model_type = "qwen3_bidirec"
+
     try:
         return importlib.import_module(f"mlx_embeddings.models.{model_type}")
     except ImportError:


### PR DESCRIPTION
# Add Qwen3 Bidirectional encoder (voyage-4-nano support)

## Summary

Adds a new `qwen3_bidirec.py` model module that supports Qwen3-based **bidirectional encoder** embedding models — most notably [voyageai/voyage-4-nano](https://huggingface.co/voyageai/voyage-4-nano), Voyage AI's first open-weights release (Apache 2.0, January 2026, 340M params, 2048d Matryoshka head, 8K context).

Mirrors the existing `llama_bidirec.py` pattern: a separate module file alongside `qwen3.py`, dispatched via `model_type` in the HF config. Same idea, Qwen3 internals.

## What this is solving

The upstream voyage-4-nano config declares:

```json
{
  "model_type": "qwen3",
  "use_bidirectional_attention": true,
  "num_labels": 2048
}
```

The current `qwen3.py` Model class is decoder-only — causal mask, last-token pooling, no projection head. Trying to load voyage-4-nano (either via `mlx_embeddings.convert` or `load`) fails with:

```
ValueError: Received 1 parameters not in model:
model.linear.weight.
```

…because the upstream HF module `Qwen3BidirectionalModel` stores its Matryoshka projection at `self.linear` (top-level, alongside `self.model`), and the existing `qwen3.Model` has no slot for it.

## What changed

| File | Change |
|---|---|
| `mlx_embeddings/models/qwen3_bidirec.py` | **New.** Bidirectional Qwen3 with optional Matryoshka projection. Reuses `Qwen3DecoderLayer` from `qwen3.py` and `mean_pooling` from `pooling.py`. |
| `mlx_embeddings/utils.py` (`_get_model_arch`) | When `model_type == "qwen3"` AND config has `use_bidirectional_attention=True`, route to `qwen3_bidirec`. Otherwise route as before. |
| `README.md` | Adds the new architecture to the supported-models list. |

**No new runtime dependencies.** **`qwen3.py` is untouched** — existing Qwen3 / Qwen3-Embedding-* models that don't set the flag continue to load via the original module.

## Design notes

* Subclasses `qwen3.ModelArgs` rather than redefining all fields — keeps the schema in one place and means `Qwen3DecoderLayer` works on either ModelArgs without changes.
* The projection slot lives at `self.linear` (top-level, not nested under `self.model`) because that matches the upstream HF safetensors layout. `sanitize()` has a special case for `linear.weight` / `linear.bias` to prevent the existing `model.` prefix rule from wrongly rewriting it.
* Routing decision: a static `MODEL_REMAPPING` entry would have been the smaller diff, but it can't condition on more than `model_type`. The two-condition check (`model_type == "qwen3"` AND `use_bidirectional_attention=True`) is the smallest extension that makes upstream voyage configs "just work" without users editing config.json.

## Validation

### 1. Convert the upstream snapshot

```bash
python -m mlx_embeddings.convert \
    --hf-path voyageai/voyage-4-nano \
    --mlx-path ./voyage-4-nano-bf16 \
    --dtype bfloat16
```

### 2. Load + embed a sentence and verify routing and output shape

```bash
python <<'PY'
from mlx_embeddings.utils import load
model, tok = load("./voyage-4-nano-bf16")
assert type(model).__module__ == "mlx_embeddings.models.qwen3_bidirec"
assert model.linear is not None
assert model.linear.weight.shape == (2048, 1024)
ids = tok("hello world", return_tensors="mlx",
          padding=True, truncation=True)
out = model(ids["input_ids"], attention_mask=ids["attention_mask"])
assert out.text_embeds.shape == (1, 2048)
print("voyage path ok")
PY
```

### 3. Regression check on the existing Qwen3 decoder path

```bash
python <<'PY'
from mlx_embeddings.utils import load
model, _ = load("mlx-community/Qwen3-Embedding-0.6B-8bit")
assert type(model).__module__ == "mlx_embeddings.models.qwen3"
print("decoder Qwen3 path unchanged")
PY
```
