### PR TITLE
fix(qwen3): avoid out-of-memory crash on long-context embeddings

### DIFF
--- a/mlx_embeddings/models/qwen3.py
+++ b/mlx_embeddings/models/qwen3.py
@@ -207,7 +207,9 @@ class Qwen3Attention(nn.Module):
 
         Args:
             hidden_states: Input hidden states, shape (batch_size, seq_len, hidden_size)
-            attention_mask: Attention mask, shape (batch_size, 1, seq_len, seq_len)
+            attention_mask: Either a dense additive mask of shape
+                (batch_size, 1, seq_len, seq_len) or the string ``"causal"``
+                (passed through to ``mx.fast.scaled_dot_product_attention``).
 
         Returns:
             Attention output, shape (batch_size, seq_len, hidden_size)
@@ -257,10 +259,32 @@ class Qwen3Attention(nn.Module):
 
             attn_weights = (query_states @ key_states.transpose(0, 1, 3, 2)) * scale
 
-            if attention_mask is not None:
-                attn_weights = attn_weights + attention_mask
+            mask = attention_mask
+            if isinstance(mask, str):
+                # Fast SDPA accepts mask="causal"; the manual path needs an
+                # explicit additive mask. For square self-attention
+                # (T_q == T_kv) lower-right causal equals lower-triangular.
+                if mask == "causal":
+                    t_q = query_states.shape[-2]
+                    tri = mx.tril(mx.ones((t_q, t_q), dtype=mx.bool_))
+                    mask = mx.where(tri, 0.0, -mx.inf).astype(attn_weights.dtype)
+                else:
+                    # Bare raise: implicit __context__ chaining keeps the original
+                    # fast-SDPA error visible ("During handling of...") without
+                    # claiming it *caused* this unsupported-mask error.
+                    raise ValueError(f"Unsupported string attention mask: {mask!r}")
+
+            if mask is not None:
+                attn_weights = attn_weights + mask
 
             attn_weights = mx.softmax(attn_weights, axis=-1)
+            # Fully-masked rows (e.g. a left-padding query position whose only
+            # causal keys are themselves padded) softmax to NaN. The fused SDPA
+            # path returns finite rows for this case, so match it: zero the NaNs
+            # to stop them propagating into later layers through the causal
+            # residual stream. Such rows are padding positions discarded by
+            # last_token_pool, so zeroing them does not affect any real output.
+            attn_weights = mx.where(mx.isnan(attn_weights), 0.0, attn_weights)
             attn_output = attn_weights @ value_states
 
         # Reshape back to (batch_size, seq_len, hidden_size)
@@ -392,7 +416,9 @@ class Qwen3Model(nn.Module):
 
         Args:
             input_ids: Input token IDs, shape (batch_size, seq_len)
-            attention_mask: Attention mask, shape (batch_size, seq_len) or (batch_size, 1, seq_len, seq_len)
+            attention_mask: Attention mask, shape (batch_size, seq_len) or
+                (batch_size, 1, seq_len, seq_len). The 2D form must use 0/1
+                integer values (1 = attended, 0 = padded).
 
         Returns:
             Hidden states, shape (batch_size, seq_len, hidden_size)
@@ -402,23 +428,40 @@ class Qwen3Model(nn.Module):
         # Get token embeddings
         hidden_states = self.embed_tokens(input_ids)
 
-        # Create or process attention mask
+        # Create or process attention mask.
+        #
+        # When there are no padded positions (single input, or an equal-length
+        # batch) use MLX's fused "causal" mask instead of materializing a dense
+        # (batch, 1, seq, seq) additive mask. That dense mask is O(batch * seq^2)
+        # and overflows Metal's max buffer at long context (e.g. batch=32,
+        # seq=32768 -> 128 GiB). The fused kernel uses O(1) mask memory and is
+        # numerically identical for square self-attention (T_q == T_kv) -- and
+        # bit-identical on the MLX/Metal versions tested.
         if attention_mask is None:
-            # Create causal mask for autoregressive generation
-            attention_mask = self._create_causal_mask(seq_length, hidden_states.dtype)
+            # Direct-call path: the top-level Model.__call__ converts None into
+            # an all-ones 2D mask before reaching here, so this branch is hit
+            # only when Qwen3Model is called directly.
+            attention_mask = "causal"
         elif attention_mask.ndim == 2:
-            # Convert padding mask to additive mask and combine with causal mask
-            # attention_mask shape: (batch_size, seq_len) -> (batch_size, 1, 1, seq_len)
-            padding_mask = attention_mask[:, None, None, :]
-            padding_mask = mx.where(padding_mask == 0, -mx.inf, 0.0).astype(
-                hidden_states.dtype
-            )
-
-            # Create causal mask
-            causal_mask = self._create_causal_mask(seq_length, hidden_states.dtype)
-
-            # Combine masks (broadcast padding mask to match causal mask shape)
-            attention_mask = causal_mask + padding_mask
+            # The 2D mask is a 0/1 padding mask (1 = attend, 0 = padded), not an
+            # additive mask. `bool(...)` forces a host eval, which is illegal
+            # under mx.compile / mx.vmap; the embedding forward is not compiled,
+            # but guard the read so a future compiled caller degrades to the
+            # (always correct) dense path instead of crashing on it.
+            try:
+                unpadded = bool((attention_mask == 1).all())
+            except ValueError:
+                unpadded = False  # tracing (compile/vmap): take the dense path
+            if unpadded:
+                attention_mask = "causal"
+            else:
+                # Padded batch: build the dense additive mask (O(batch * seq^2)).
+                padding_mask = attention_mask[:, None, None, :]
+                padding_mask = mx.where(padding_mask == 0, -mx.inf, 0.0).astype(
+                    hidden_states.dtype
+                )
+                causal_mask = self._create_causal_mask(seq_length, hidden_states.dtype)
+                attention_mask = causal_mask + padding_mask
 
         # Apply transformer layers
         for layer in self.layers:

--- a/mlx_embeddings/tests/test_models.py
+++ b/mlx_embeddings/tests/test_models.py
@@ -725,5 +725,140 @@ class TestModels(unittest.TestCase):
         self.assertTrue(mx.all(scores <= 1.0).item())
 
 
+class TestQwen3CausalMask(unittest.TestCase):
+    def _small_config(self):
+        from mlx_embeddings.models import qwen3
+
+        return qwen3.ModelArgs(
+            hidden_size=64,
+            num_hidden_layers=2,
+            intermediate_size=128,
+            num_attention_heads=4,
+            num_key_value_heads=2,  # GQA: exercises mx.repeat path
+            head_dim=16,
+            vocab_size=100,
+            rms_norm_eps=1e-6,
+        )
+
+    def test_attention_fallback_handles_causal_string(self):
+        from mlx_embeddings.models import qwen3
+
+        mx.random.seed(0)
+        config = self._small_config()
+        attn = qwen3.Qwen3Attention(config)
+        mx.eval(attn.parameters())
+
+        h = mx.random.normal((2, 5, config.hidden_size))
+        out_fast = attn(h, attention_mask="causal")
+        mx.eval(out_fast)
+
+        # Force the manual fallback by making fast SDPA raise.
+        with patch(
+            "mlx.core.fast.scaled_dot_product_attention",
+            side_effect=RuntimeError("forced fallback"),
+        ) as mock_sdpa:
+            out_fallback = attn(h, attention_mask="causal")
+            mx.eval(out_fallback)
+        mock_sdpa.assert_called()
+
+        self.assertTrue(
+            mx.allclose(out_fast, out_fallback, atol=1e-4).item(),
+            "manual fallback must match fast SDPA for a causal mask",
+        )
+
+    def test_fallback_left_padding_no_nan(self):
+        # Left padding makes the leading causal query rows fully masked; in the
+        # manual fallback those rows softmax to NaN. Verify the fallback zeroes
+        # them so NaN does not leak into the pooled embedding (regression for the
+        # forced-fallback left-padding path the OOM fix touches).
+        from mlx_embeddings.models import qwen3
+
+        mx.random.seed(0)
+        config = self._small_config()
+        model = qwen3.Model(config)
+        mx.eval(model.parameters())
+
+        ids = mx.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
+        am_left = mx.array([[0, 0, 1, 1, 1], [0, 1, 1, 1, 1]], dtype=mx.int32)
+
+        with patch(
+            "mlx.core.fast.scaled_dot_product_attention",
+            side_effect=RuntimeError("forced fallback"),
+        ) as mock_sdpa:
+            out = model(ids, am_left).text_embeds
+            mx.eval(out)
+        mock_sdpa.assert_called()
+
+        self.assertFalse(
+            bool(mx.isnan(out).any().item()),
+            "manual fallback must not leak NaN from fully-masked left-padding rows",
+        )
+        self.assertEqual(out.shape, (2, config.hidden_size))
+
+    def test_attention_fallback_rejects_unknown_string_mask(self):
+        from mlx_embeddings.models import qwen3
+
+        mx.random.seed(0)
+        config = self._small_config()
+        attn = qwen3.Qwen3Attention(config)
+        mx.eval(attn.parameters())
+
+        h = mx.random.normal((2, 5, config.hidden_size))
+        with patch(
+            "mlx.core.fast.scaled_dot_product_attention",
+            side_effect=RuntimeError("forced fallback"),
+        ):
+            with self.assertRaises(ValueError):
+                mx.eval(attn(h, attention_mask="full"))
+
+    def test_model_skips_dense_mask_when_unpadded(self):
+        from mlx_embeddings.models import qwen3
+
+        mx.random.seed(0)
+        config = self._small_config()
+        model = qwen3.Model(config)
+        mx.eval(model.parameters())
+
+        ids = mx.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
+
+        # Spy on the dense-mask builder. Assigning a plain function to the class
+        # makes it a bound method, so `self` is passed normally.
+        calls = []
+        original = qwen3.Qwen3Model._create_causal_mask
+
+        def spy(self, seq_length, dtype):
+            calls.append(seq_length)
+            return original(self, seq_length, dtype)
+
+        qwen3.Qwen3Model._create_causal_mask = spy
+        try:
+            # All-ones mask (no padding) -> fused "causal", no dense mask built.
+            am_ones = mx.ones((2, 5), dtype=mx.int32)
+            out_ones = model(ids, am_ones).text_embeds
+            mx.eval(out_ones)
+            self.assertEqual(calls, [], "unpadded input must not build a dense mask")
+
+            # Padded mask -> dense path unchanged, dense mask IS built.
+            calls.clear()
+            am_pad = mx.array([[0, 0, 1, 1, 1], [0, 1, 1, 1, 1]], dtype=mx.int32)
+            out_pad = model(ids, am_pad).text_embeds
+            mx.eval(out_pad)
+            self.assertGreater(
+                len(calls), 0, "padded input must still build a dense mask"
+            )
+
+            # Core forward with attention_mask=None -> fused "causal".
+            calls.clear()
+            hidden = model.model(ids, attention_mask=None)
+            mx.eval(hidden)
+            self.assertEqual(calls, [], "None mask must not build a dense mask")
+        finally:
+            qwen3.Qwen3Model._create_causal_mask = original
+
+        self.assertEqual(out_ones.shape, (2, config.hidden_size))
+        self.assertEqual(out_pad.shape, (2, config.hidden_size))
+        self.assertEqual(hidden.shape, (2, 5, config.hidden_size))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What's wrong

Embedding a long batch with a Qwen3 model can crash before any real work happens. `Qwen3Model.__call__` builds a dense `(batch, 1, seq, seq)` attention mask on every forward pass, and that tensor grows with the *square* of the sequence length. At Qwen3's full 32k context, a batch of 32 needs a single ~128 GiB allocation — more than Metal will hand out (~80.6 GiB on this machine) — so `POST /v1/embeddings` fails before the model computes anything:

```
[metal::malloc] Attempting to allocate 137438953472 bytes which is greater than the maximum allowed buffer size of 86586540032 bytes.
```

The key point is that it's the *mask* that blows up, not the attention math. `mx.fast.scaled_dot_product_attention` already knows how to apply a causal mask cheaply: pass it `mask="causal"` and it never materializes a dense tensor at all. The trouble is that `qwen3.py` builds the full `(B,1,S,S)` array by hand and hands *that* to SDPA, so it never reaches the cheap path. (The top-level `Model.__call__` fills in an all-ones mask whenever the caller doesn't supply one, so even a single unpadded sequence ends up on the expensive branch.)

This has been the behavior since the file was first added in #34.

## The fix

When there's no padding to worry about, pass `mask="causal"` and let the fused kernel do the work. When the batch genuinely has padding, build the dense mask exactly as before — that path is left untouched.

Concretely, `Qwen3Model.__call__` now looks at the 2D mask:

- no mask, or an all-ones mask (nothing is padded) → `"causal"`, the cheap fused path;
- any zeros (real padding) → the original dense mask.

This is already how the rest of the package handles causal masking — `lfm2.py`, `gemma3_text.py`, `siglip.py`, and others all pass `"causal"` to the fused kernel. The only thing changing here is *which mask value* `qwen3.py` hands over; the attention call itself is the same, and there's no new dependency.

For the unpadded case the result is identical to the old code. The model only ever does square self-attention (query and key lengths are always equal), and for that a causal mask and a lower-triangular mask are the same thing — so the output matches the old dense path bit-for-bit (`max|delta| = 0.0`) on the versions I tested. It isn't an approximation.

Two supporting details worth calling out:

- The all-ones check reads the mask's values, which isn't allowed under `mx.compile` / `mx.vmap`. The embedding forward isn't compiled today, but I wrapped the check in a `try/except` so a future compiled caller falls back to the (always correct) dense path instead of crashing. I kept the check inside the model rather than asking callers to pass `None`, because the real entry point — `processor.encode(...)` → `model(**inputs)` — hands the model an all-ones mask, not `None`. Moving the decision to the caller would quietly miss the common case and bring the OOM straight back.
- The manual-attention fallback (only used if the fused kernel ever raises) now resolves `"causal"` to an explicit lower-triangular mask, and zeroes any NaN rows after softmax. A fully-masked row — say a left-padding position whose only visible keys are themselves padding — would otherwise produce NaNs that leak into later layers. The fused path already handles this; now the fallback matches it.

## Verifying it

On mlx 0.31.2 (Apple Silicon):

- Unpadded output is identical to the old dense mask (`max|delta| = 0.0`).
- The manual fallback matches the fused path (`mx.allclose`, atol 1e-4) when SDPA is forced to raise.
- A long single input at S=16384 drops peak memory from ~4970 MiB to ~2538 MiB, and the S=32768 / batch-32 case never builds the dense tensor at all.
- Padded batches are byte-for-byte unchanged.
- `Qwen3Model` wrapped in `mx.compile` now runs (falling back to the dense path) instead of crashing.
- `python -m pytest mlx_embeddings/tests/test_models.py::TestQwen3CausalMask` → 4 passed.

<details>
<summary>Self-contained reproducer (no weights, no network)</summary>

```python
import mlx.core as mx

B, S = 32, 32768
print("dense (B,1,S,S) f32 mask bytes =", B * S * S * 4)   # 137438953472

# BUGGY PATH: exactly what Qwen3Model.__call__ builds for an all-ones 2D mask.
am = mx.ones((B, S), dtype=mx.int32)
padding = mx.where(am[:, None, None, :] == 0, -mx.inf, 0.0).astype(mx.float32)            # (B,1,1,S)
causal = mx.where(mx.tril(mx.ones((S, S), dtype=mx.bool_)), 0.0, -mx.inf).astype(mx.float32)[None, None]  # (1,1,S,S)
try:
    mx.eval(causal + padding)                        # (B,1,S,S) -> OOM
    print("allocated dense mask (unexpected)")
except Exception as e:
    print("FAILED as expected:", e)

# FIXED PATH: the fused string mask the fix passes instead; no dense tensor is built.
q = k = v = mx.zeros((1, 4, S, 128), dtype=mx.float16)
out = mx.fast.scaled_dot_product_attention(q, k, v, scale=1.0, mask="causal")
mx.eval(out)
print("fused mask='causal' OK:", out.shape)
```

Verified output:

```
dense (B,1,S,S) f32 mask bytes = 137438953472
FAILED as expected: [metal::malloc] Attempting to allocate 137438953472 bytes which is greater than the maximum allowed buffer size of 86586540032 bytes.
fused mask='causal' OK: (1, 4, 32768, 128)
```

</details>

## What this doesn't cover

The fast path kicks in only when there's no padding. A 2D mask with any zero — a genuinely padded, unequal-length batch — still builds the dense mask, so padded callers see no change. Note that this 2D mask is a 0/1 padding mask (1 = attend, 0 = padded), not an additive mask.

The bidirectional encoders (`gemma3_text`, `llama_bidirec`, `llama_nemotron_vl`, `modernbert`) and `qwen3_vl` build the same dense mask and likely hit the same wall at long context, but they need a different fix — a causal string would change their semantics — so I've left them out of this PR. Happy to follow up on them separately.

## Background

I couldn't find an existing issue or PR for this OOM (searched all issues and PRs). #34, which introduced the dense mask, advertised that Qwen3 is "not limited to 512 tokens" — this is the long-context use that change was meant to enable. #66 (open) adds a separate bidirectional encoder and leaves `qwen3.py` alone.
