### PR TITLE
Add classify() and a convert-time embedding stamp

### DIFF
--- a/mlx_embeddings/__init__.py
+++ b/mlx_embeddings/__init__.py
@@ -8,5 +8,5 @@ __email__ = "prince.gdt@gmail.com"
 os.environ.setdefault("TRANSFORMERS_NO_ADVISORY_WARNINGS", "1")
 
 from .convert import convert
-from .utils import classify, generate, load
+from .utils import classify, embed, generate, load
 from .version import __version__

--- a/mlx_embeddings/__init__.py
+++ b/mlx_embeddings/__init__.py
@@ -8,5 +8,5 @@ __email__ = "prince.gdt@gmail.com"
 os.environ.setdefault("TRANSFORMERS_NO_ADVISORY_WARNINGS", "1")
 
 from .convert import convert
-from .utils import generate, load
+from .utils import classify, generate, load
 from .version import __version__

--- a/mlx_embeddings/convert.py
+++ b/mlx_embeddings/convert.py
@@ -10,6 +10,8 @@ import mlx.nn as nn
 from mlx.utils import tree_flatten, tree_unflatten
 
 from .utils import (
+    EMBEDDINGS_CONFIG_KEY,
+    embedding_metadata,
     fetch_from_hub,
     get_model_path,
     save_config,
@@ -239,6 +241,7 @@ def convert(
 
     tokenizer.save_pretrained(mlx_path)
 
+    config[EMBEDDINGS_CONFIG_KEY] = embedding_metadata(config)
     save_config(config, config_path=mlx_path / "config.json")
 
     if upload_repo is not None:

--- a/mlx_embeddings/tests/test_classify.py
+++ b/mlx_embeddings/tests/test_classify.py
@@ -1,0 +1,103 @@
+import json
+
+from mlx_embeddings import classify
+
+
+def _write(path, obj):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj))
+
+
+def test_pooling_dir_marks_text_embedding(tmp_path):
+    _write(tmp_path / "1_Pooling" / "config.json", {"pooling_mode_mean_tokens": True})
+    result = classify(
+        {"model_type": "qwen3", "architectures": ["Qwen3ForCausalLM"]}, tmp_path
+    )
+    assert result == {"is_embedding": True, "modality": "text"}
+
+
+def test_chat_model_without_pooling_is_not_embedding(tmp_path):
+    (tmp_path / "config.json").write_text("{}")
+    result = classify(
+        {"model_type": "qwen3", "architectures": ["Qwen3ForCausalLM"]}, tmp_path
+    )
+    assert result == {"is_embedding": False, "modality": None}
+
+
+def test_modules_json_pooling_marks_embedding(tmp_path):
+    _write(
+        tmp_path / "modules.json",
+        [
+            {"idx": 0, "type": "sentence_transformers.models.Transformer"},
+            {"idx": 1, "type": "sentence_transformers.models.Pooling"},
+        ],
+    )
+    assert classify({"model_type": "unknownarch"}, tmp_path)["is_embedding"] is True
+
+
+def test_modules_json_without_pooling_is_not_embedding(tmp_path):
+    _write(
+        tmp_path / "modules.json",
+        [{"idx": 0, "type": "sentence_transformers.models.Transformer"}],
+    )
+    assert classify({"model_type": "unknownarch"}, tmp_path)["is_embedding"] is False
+
+
+def test_config_sentence_transformers_marks_embedding(tmp_path):
+    _write(
+        tmp_path / "config_sentence_transformers.json",
+        {"__version__": {"sentence_transformers": "3.0.0"}},
+    )
+    assert classify({"model_type": "unknownarch"}, tmp_path)["is_embedding"] is True
+
+
+def test_vision_embedder_reports_vision_modality(tmp_path):
+    _write(tmp_path / "1_Pooling" / "config.json", {"pooling_mode_mean_tokens": True})
+    result = classify({"model_type": "siglip", "vision_config": {}}, tmp_path)
+    assert result == {"is_embedding": True, "modality": "vision"}
+
+
+def test_missing_model_path_returns_not_embedding():
+    assert classify({"model_type": "unknownarch"})["is_embedding"] is False
+
+
+def test_explicit_stamp_marks_vision_embedding_without_pooling():
+    config = {
+        "model_type": "siglip",
+        "vision_config": {},
+        "mlx_embeddings": {"kind": "embedding", "modality": "vision"},
+    }
+    assert classify(config) == {"is_embedding": True, "modality": "vision"}
+
+
+def test_explicit_generation_stamp_is_not_embedding():
+    config = {"model_type": "qwen3", "mlx_embeddings": {"kind": "generation"}}
+    assert classify(config) == {"is_embedding": False, "modality": None}
+
+
+def test_stamp_without_modality_is_derived_from_config():
+    config = {
+        "model_type": "siglip",
+        "vision_config": {},
+        "mlx_embeddings": {"kind": "embedding"},
+    }
+    assert classify(config) == {"is_embedding": True, "modality": "vision"}
+
+
+def test_labeled_vision_type_without_pooling_or_stamp():
+    assert classify({"model_type": "siglip"}) == {
+        "is_embedding": True,
+        "modality": "vision",
+    }
+
+
+def test_labeled_text_type_without_pooling_or_stamp():
+    assert classify({"model_type": "bert"}) == {
+        "is_embedding": True,
+        "modality": "text",
+    }
+
+
+def test_generative_twin_type_is_not_labeled():
+    config = {"model_type": "qwen3", "architectures": ["Qwen3ForCausalLM"]}
+    assert classify(config) == {"is_embedding": False, "modality": None}

--- a/mlx_embeddings/utils.py
+++ b/mlx_embeddings/utils.py
@@ -60,6 +60,124 @@ def _get_classes(config: dict):
     return arch.Model, arch.ModelArgs, None, None
 
 
+_SENTENCE_TRANSFORMER_FILES = (
+    "config_sentence_transformers.json",
+    "sentence_bert_config.json",
+)
+
+EMBEDDINGS_CONFIG_KEY = "mlx_embeddings"
+
+# Embedding architectures whose ``model_type`` has no generative twin, so the
+# type alone is a safe label. Types that are also used by chat/VLM models
+# (``qwen3``, ``qwen3_vl``, ``gemma3_text``, ``lfm2``) are intentionally omitted:
+# the type cannot tell an embedder from its generative twin, so those are
+# resolved per model by the config stamp or the pooling fallback.
+_LABELED_EMBEDDING_MODELS = {
+    "bert": "text",
+    "modernbert": "text",
+    "xlm_roberta": "text",
+    "llama_bidirec": "text",
+    "siglip": "vision",
+    "colqwen2_5": "vision",
+    "colidefics3": "vision",
+}
+
+
+def _is_sentence_transformer(model_path: Optional[Union[str, Path]]) -> bool:
+    """Whether the repository declares a sentence-transformers pooling step.
+
+    Pooling is the artifact that turns a backbone into an embedder, so its
+    presence — not the model family — is what distinguishes an embedding model
+    such as Qwen3-Embedding from the identically-architected Qwen3 chat model.
+    """
+    if model_path is None:
+        return False
+    path = Path(model_path)
+    if (path / "1_Pooling" / "config.json").exists():
+        return True
+    if any((path / name).exists() for name in _SENTENCE_TRANSFORMER_FILES):
+        return True
+    modules = path / "modules.json"
+    if modules.exists():
+        try:
+            entries = json.loads(modules.read_text())
+        except (OSError, ValueError):
+            return False
+        return any("Pooling" in str(entry.get("type", "")) for entry in entries)
+    return False
+
+
+def _embedding_modality(config: Dict[str, Any]) -> str:
+    vision_markers = ("vision_config", "vision_tower", "image_processor_type")
+    return "vision" if any(marker in config for marker in vision_markers) else "text"
+
+
+def embedding_metadata(config: Dict[str, Any]) -> Dict[str, str]:
+    """The stamp :func:`convert` writes into ``config.json`` so :func:`classify`
+    can identify a converted model without heuristics.
+
+    Returns ``{"kind": "embedding", "modality": "text" | "vision"}``. Modality
+    comes from whether the architecture exposes both a text and a vision config.
+    """
+    try:
+        _, _, text_config, vision_config = _get_classes(config)
+        modality = (
+            "vision"
+            if text_config is not None and vision_config is not None
+            else "text"
+        )
+    except (ImportError, ValueError, KeyError):
+        modality = _embedding_modality(config)
+    return {"kind": "embedding", "modality": modality}
+
+
+def classify(
+    config: Dict[str, Any], model_path: Optional[Union[str, Path]] = None
+) -> Dict[str, Any]:
+    """Classify a model as an embedding model (and its modality) without loading weights.
+
+    Resolution order:
+
+    1. An explicit ``config["mlx_embeddings"]["kind"]`` stamp written by
+       :func:`convert`. Authoritative, and the only signal that can distinguish
+       an embedder from an identically-architected generative model (e.g.
+       Qwen3-Embedding vs the Qwen3 chat model).
+    2. A ``model_type`` in ``_LABELED_EMBEDDING_MODELS`` — the maintained set of
+       embedding architectures whose type has no generative twin.
+    3. Otherwise a sentence-transformers pooling layout (a ``1_Pooling/``
+       directory, ``config_sentence_transformers.json``,
+       ``sentence_bert_config.json``, or a ``modules.json`` Pooling module),
+       which covers text embedders not converted by this library.
+
+    Args:
+        config: The parsed ``config.json``.
+        model_path: Local path to the model directory, used for the pooling
+            fallback. Without it, only the stamp and labeled type are consulted.
+
+    Returns:
+        ``{"is_embedding": bool, "modality": "text" | "vision" | None}``.
+    """
+    stamp = config.get(EMBEDDINGS_CONFIG_KEY)
+    if isinstance(stamp, dict) and stamp.get("kind"):
+        is_embedding = stamp["kind"] == "embedding"
+        modality = stamp.get("modality") or _embedding_modality(config)
+        return {
+            "is_embedding": is_embedding,
+            "modality": modality if is_embedding else None,
+        }
+
+    model_type = str(config.get("model_type", "")).lower().replace("-", "_")
+    labeled_modality = _LABELED_EMBEDDING_MODELS.get(model_type)
+    if labeled_modality is not None:
+        return {"is_embedding": True, "modality": labeled_modality}
+
+    is_embedding = _is_sentence_transformer(model_path)
+    return {
+        "is_embedding": is_embedding,
+        "modality": _embedding_modality(config) if is_embedding else None,
+    }
+
+
 def get_model_path(path_or_hf_repo: str, revision: Optional[str] = None) -> Path:
     """
     Ensures the model is available locally. If the path does not exist locally,

--- a/mlx_embeddings/utils.py
+++ b/mlx_embeddings/utils.py
@@ -738,3 +738,30 @@ def generate(
         outputs = model(**inputs)
 
     return outputs
+
+
+def embed(
+    model: nn.Module,
+    processor: Union[PreTrainedTokenizer, TokenizerWrapper, AutoProcessor],
+    texts: Union[str, List[str]],
+    max_length: int = 512,
+    **kwargs,
+) -> List[List[float]]:
+    """Return normalized text embeddings for ``texts`` as plain Python lists.
+
+    A thin convenience wrapper over :func:`generate` that extracts the
+    normalized ``text_embeds`` and materializes them as one row vector per
+    input string, ready to be serialized (e.g. by an OpenAI-compatible
+    ``/v1/embeddings`` endpoint).
+    """
+    if isinstance(texts, str):
+        texts = [texts]
+    outputs = generate(model, processor, texts, max_length=max_length, **kwargs)
+    embeddings = getattr(outputs, "text_embeds", None)
+    if embeddings is None:
+        raise ValueError(
+            "The model did not return `text_embeds`; it may not be a text "
+            "embedding model."
+        )
+    mx.eval(embeddings)
+    return embeddings.tolist()


### PR DESCRIPTION
Wanted to integrate mlx-embeddings as a provider behind nativ, just as a api provider for embedding.

But an issue is that vlm and emb. simultaneously exist in this library, this pr allows me to push a pr up to nativ( they will simply be accessible through api ) that will be able to reference their config key to permit embedding api call. 

this pr just labels existing embedding models, and for future included ones, has a function(`classify`) to label them

cc: @Blaizzy 

